### PR TITLE
fix(wrong card playable)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "_socha"
-version = "3.5.1"
+version = "3.5.2"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "socha"
-version = "3.5.1"
+version = "3.5.2"
 authors = [{ name = "maxblan", email = "stu222782@mail.uni-kiel.de" }]
 description = "Dieses Paket ist für die Software-Challenge Germany 2025, bei der in dieser Saison das Spiel 'Hase und Igel' im Mittelpunkt steht."
 readme = "README.md"

--- a/src/plugin/action/card.rs
+++ b/src/plugin/action/card.rs
@@ -80,18 +80,13 @@ impl Card {
             }
             Card::EatSalad => current.eat_salad(state)?,
             Card::SwapCarrots => {
-                let last_lettuce_position = state
-                    .board
-                    .get_previous_field(Field::Salad, state.board.track.len() - 1)
-                    .ok_or_else(|| {
-                        HUIError::new_err("Unable to find the last lettuce field position")
-                    })?;
+                let last_lettuce_position = 57;
 
-                if current.position > last_lettuce_position
-                    || other.position > last_lettuce_position
+                if current.position >= last_lettuce_position
+                    || other.position >= last_lettuce_position
                 {
                     return Err(HUIError::new_err(
-                    "You can only play this card if both players haven't passed the last lettuce field",
+                    "You can only play this card if both players are before the last lettuce field",
                 ));
                 }
 


### PR DESCRIPTION
## Description
Resolved an issue where the SwapCarrots card could be played when it shouldn't have been allowed.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
I played several rounds, and the error reported on Discord did not occur. However, I did not specifically test for that particular issue as I found no way of creating a game that has this condition.

## What Has Been Changed?
Added a constant lettuce position (as it does not change). And fixed the condition in which when a player was on a lattuce the check was okay but it should report that it was not

## Checklist:
- [x] My code follows the style guidelines of this project (hopefully)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (self-explaining)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
