### PR TITLE
Add build py version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,13 @@ Dieses Repository enthält das Python-Paket für die [Software-Challenge Germany
 
 ## Inhaltsverzeichnis
 
-- [Python-Client für die Software-Challenge Germany 2025](#python-client-für-die-software-challenge-germany-2025)
-  - [Inhaltsverzeichnis](#inhaltsverzeichnis)
-  - [Installation](#installation)
-    - [Global](#global)
-    - [Virtuelle Umgebung](#virtuelle-umgebung)
-  - [Erste Schritte](#erste-schritte)
-    - [Startargumente](#startargumente)
-  - [Vorbereitung des Spielers für den Wettbewerb](#vorbereitung-des-spielers-für-den-wettbewerb)
-  - [Lokale Entwicklung](#lokale-entwicklung)
+- [Installation](#installation)
+  - [Global](#global)
+  - [Virtuelle Umgebung](#virtuelle-umgebung)
+- [Erste Schritte](#erste-schritte)
+  - [Startargumente](#startargumente)
+- [Vorbereitung des Spielers für den Wettbewerb](#vorbereitung-des-spielers-für-den-wettbewerb)
+- [Lokale Entwicklung](#lokale-entwicklung)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ Dieses Repository enthält das Python-Paket für die [Software-Challenge Germany
 
 ## Inhaltsverzeichnis
 
-- [Installation](#installation)
-  - [Global](#global)
-  - [Virtuelle Umgebung](#virtuelle-umgebung)
-- [Erste Schritte](#erste-schritte)
-  - [Startargumente](#start-arguments)
-- [Vorbereitung des Spielers auf den Wettbewerb](#vorbereitung-des-spielers-für-den-wettbewerb)
-- [Lokale Entwicklung](#lokale-entwicklung)
+- [Python-Client für die Software-Challenge Germany 2025](#python-client-für-die-software-challenge-germany-2025)
+  - [Inhaltsverzeichnis](#inhaltsverzeichnis)
+  - [Installation](#installation)
+    - [Global](#global)
+    - [Virtuelle Umgebung](#virtuelle-umgebung)
+  - [Erste Schritte](#erste-schritte)
+    - [Startargumente](#startargumente)
+  - [Vorbereitung des Spielers für den Wettbewerb](#vorbereitung-des-spielers-für-den-wettbewerb)
+  - [Lokale Entwicklung](#lokale-entwicklung)
 
 ## Installation
 
@@ -138,16 +140,24 @@ Falls die Logik von der Konsole aus ausgeführt werden soll, können Startargume
 | **-b, --build**        | Baut dieses Skript zu einem Paket mit all seinen Abhängigkeiten.                                 |
 | **-d, --directory**    | Das Verzeichnis, in dem das Paket erstellt werden soll.                                          |
 | **-a, --architecture** | Die Architektur des Pakets.                                                                      |
+| **--python-version**   | Die Python-Version für den Build. Der Standardwert ist '3.10'.                                   |
 
 ## Vorbereitung des Spielers für den Wettbewerb
 
-> Das Wettbewerbssystem läuft auf einem Linux-System mit einer `x86_64`-Architektur. Um den Client auf dem Wettbewerbssystem zu verwenden, muss das Socha-Paket für die Plattform `manylinux2014_x86_64` und die Python-Version `310` heruntergeladen werden.
+> Das Wettbewerbssystem läuft auf einem Linux-System mit einer `x86_64`-Architektur. Um den Client auf dem Wettbewerbssystem zu verwenden, muss das Socha-Paket für die Plattform `manylinux2014_x86_64` und die Python-Version `310` oder `312` heruntergeladen werden.
 
 Um sicherzustellen, dass der Player im Wettbewerbssystem verwendbar ist, müssen alle Abhängigkeiten heruntergeladen werden, da das System auf einem Docker-Container ohne Internetzugang und sudo-Berechtigung ausgeführt wird.
 
-> Das Paket erleichtert die Vorbereitung! Eine Datei `requirements.txt`, die alle Abhängigkeiten auflistet, wird benötigt. Zum Starten folgenden Befehl im Terminal ausführen:
+> Das Paket erleichtert die Vorbereitung!
+> 
+> Eine Datei `requirements.txt`, die alle Abhängigkeiten auflistet, wird dafür benötigt. 
+> Jeder Bot braucht natürlich das Paket `socha`. 
+> Außerdem sollte `setuptools` in der Version `58.1.0` für Python 3.10 bzw. `75.8.0` für Python 3.12 hinzugefügt werden. \
+> Alle Abhängigkeiten kommen mit der Syntax `<paket>==<version>` in jeweils eine Zeile.
+> 
+> Zum Starten folgenden Befehl im Terminal ausführen:
 >
-> `$ python <dein_haupt_skript>.py --build -directory <dein_ordner> -architecture <ziel_architektur>`
+> `$ python <dein_haupt_skript>.py --build --directory <dein_ordner> --architecture <ziel_architektur> --python-version <3.xx>`
 >
 > Dadurch wird das Paket aktiviert und das Projekt erstellt.
 
@@ -157,6 +167,7 @@ Falls eine manuelle Vorgehensweise bevorzugt wird, folgen diese Schritte zum Her
 2. `mkdir my_player` eingeben, um ein neues Verzeichnis namens `my_player` zu erstellen. Der Verzeichnisname kann beliebig gewählt werden.
 3. Mit `cd my_player` in das Verzeichnis wechseln.
 4. Den Befehl `pip download socha --only-binary=:all: --platform manylinux2014_x86_64 --python-version 310 -d dependencies` im Verzeichnis ausführen, um die benötigten Abhängigkeiten in den Ordner `dependencies` herunterzuladen.
+     - Ändere hier `310` zu `312` wenn du mit der Python-Version 3.12 arbeitest.
 5. Alle Abhängigkeiten hinzufügen, die der Client verwendet.
 6. Ein letztes Verzeichnis mit `mkdir .pip_cache` erstellen.
 

--- a/python/socha/starter.py
+++ b/python/socha/starter.py
@@ -246,7 +246,7 @@ class Starter:
 
         parser.add_argument(
             "--python-version",
-            help="Specifies the build python version (e.g.: 10 [for python 3.10 - this is standard]).",
+            help="Specifies the build python version (e.g.: 3.10 - this is standard]).",
         )
 
         return parser.parse_args()

--- a/python/socha/starter.py
+++ b/python/socha/starter.py
@@ -37,6 +37,7 @@ class Starter:
         directory: str = None,
         architecture: str = None,
         log_level: int = logging.INFO,
+        python_version: str = '3.10',
     ):
         """
         All these arguments can be overwritten, when parsed via start arguments,
@@ -71,8 +72,9 @@ class Starter:
         self.directory: str = args.directory or directory
         self.architecture: str = args.architecture or architecture
         self.build: str = args.build or build
+        self.python_version: str = args.python_version or python_version
         if self.build:
-            builder = SochaPackageBuilder(self.directory, self.architecture)
+            builder = SochaPackageBuilder(self.directory, self.architecture, self.python_version)
             builder.build_package()
             exit(0)
 
@@ -240,6 +242,11 @@ class Starter:
             "-a",
             "--architecture",
             help="Specifies the build architecture (e.g.: manylinux1_x86_64).",
+        )
+
+        parser.add_argument(
+            "--python-version",
+            help="Specifies the build python version (e.g.: 10 [for python 3.10 - this is standard]).",
         )
 
         return parser.parse_args()

--- a/python/socha/utils/package_builder.py
+++ b/python/socha/utils/package_builder.py
@@ -14,9 +14,10 @@ import zipfile
 
 class SochaPackageBuilder:
 
-    def __init__(self, package_name, architecture):
+    def __init__(self, package_name, architecture, python_version):
         self.package_name = package_name
         self.architecture = architecture
+        self.python_version = python_version
         self.dependencies_dir = "dependencies"
         self.packages_dir = "packages"
         self.cache_dir = ".pip_cache"
@@ -50,7 +51,7 @@ class SochaPackageBuilder:
                     "download",
                     f"--platform={self.architecture}",
                     "--python-version",
-                    "3.10",
+                    f"{self.python_version}",
                     "--only-binary=:all:",
                     "-d",
                     f"{self.build_dir}/{self.package_name}/{self.dependencies_dir}",


### PR DESCRIPTION
## Description
I noticed that the Server accepts python 310 and 312, but the bot auto-build is only for 310.
So I added a feature (logic.py launch parameter) to specify the python version, the standard value still is 3.10.
Then I updated the readme to accommodate the new parameter and updated it at some other parts in the bot building section.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
23 or more test exports, which got checked by the server testing tool

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
   - no huge changes, only copy-paste, should be self-explainatory
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
   - not needed at this point, they are not even tests for the existing parameters ;)
