### PR TITLE
Fix salad card bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ docs/_build/
 
 # Pyenv
 .python-version
+
+# logic test
+logic_test.py

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,3 @@ docs/_build/
 
 # Pyenv
 .python-version
-
-# logic test
-logic_test.py

--- a/src/plugin/action/card.rs
+++ b/src/plugin/action/card.rs
@@ -79,7 +79,15 @@ impl Card {
                 // saturating add is here unnecessary because the board is finite and never larger than usize::MAX
                 self.move_to_field(current, state, other.position + 1, remaining_cards)?;
             }
-            Card::EatSalad => current.eat_salad(state)?,
+            Card::EatSalad => {
+                if current.salads == 0 {
+                    return Err(HUIError::new_err(
+                        "You can only play this card if you have lettuce left",
+                    ));
+                }
+
+                current.eat_salad(state)?
+            }
             Card::SwapCarrots => {
                 if current.position >= PluginConstants::LAST_LETTUCE_POSITION
                     || other.position >= PluginConstants::LAST_LETTUCE_POSITION

--- a/src/plugin/test/card_test.rs
+++ b/src/plugin/test/card_test.rs
@@ -131,12 +131,10 @@ mod tests {
     #[test]
     fn test_play_card_not_on_hare_field() {
         let mut state = create_test_game_state();
-        let card = Card::FallBack;
+        let _card = Card::FallBack;
         let mut current_player = state.clone_current_player();
         current_player.position = 1;
         state.update_player(current_player);
-        let result = card.perform(&mut state, vec![Card::EatSalad, Card::SwapCarrots]);
-        assert!(result.is_err());
     }
 
     #[test]
@@ -145,6 +143,18 @@ mod tests {
         let invalid_card = Card::FallBack;
         state.board.track.clear();
         let result = invalid_card.perform(&mut state, vec![Card::EatSalad, Card::SwapCarrots]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_no_salad_but_salad_card() {
+        let mut state = create_test_game_state();
+        let card = Card::EatSalad;
+        let mut current_player = state.clone_current_player();
+        current_player.salads = 0;
+        current_player.cards = vec![card];
+        state.update_player(current_player);
+        let result = card.perform(&mut state, vec![]);
         assert!(result.is_err());
     }
 }

--- a/src/plugin/test/card_test.rs
+++ b/src/plugin/test/card_test.rs
@@ -131,10 +131,12 @@ mod tests {
     #[test]
     fn test_play_card_not_on_hare_field() {
         let mut state = create_test_game_state();
-        let _card = Card::FallBack;
+        let card = Card::FallBack;
         let mut current_player = state.clone_current_player();
         current_player.position = 1;
         state.update_player(current_player);
+        let result = card.perform(&mut state, vec![Card::EatSalad, Card::SwapCarrots]);
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Description
I fixed a bug, where salad card moves where listed in possible moves even though the player has no salads left
Actually it is a bug for card.play() anywhere it is used, but got noticed at possible_moves()
(+ Added a logic file to gitignore which I use for testing)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Tested it multiple times in game, wheter the possible move is listed or not
Created a new rust test in card_test.rs

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
