### PR TITLE
Fix perform move bug

### DIFF
--- a/src/plugin/game_state.rs
+++ b/src/plugin/game_state.rs
@@ -48,23 +48,26 @@ impl GameState {
                 Some(Field::Position1) if player.position > opponent_position => {
                     player.carrots += 10
                 }
-                Some(Field::Position2) if player.position > opponent_position => {
+                Some(Field::Position2) if player.position < opponent_position => {
                     player.carrots += 30
                 }
                 _ => {}
             }
         }
 
-        update_carrots(
-            &mut new_state.player_one,
-            new_state.player_two.position,
-            &new_state.board,
-        );
-        update_carrots(
-            &mut new_state.player_two,
-            new_state.player_one.position,
-            &new_state.board,
-        );
+        if new_state.turn % 2 == 0 {
+            update_carrots(
+                &mut new_state.player_one,
+                new_state.player_two.position,
+                &new_state.board,
+            );
+        } else {
+            update_carrots(
+                &mut new_state.player_two,
+                new_state.player_one.position,
+                &new_state.board,
+            );
+        }
 
         Ok(new_state)
     }

--- a/src/plugin/move.rs
+++ b/src/plugin/move.rs
@@ -22,6 +22,7 @@ impl Move {
         if result.is_ok() {
             let mut player = state.clone_current_player();
             player.last_move = Some(self.clone());
+            state.last_move = Some(self.clone());
             state.update_player(player);
         }
         result

--- a/src/plugin/test/state_test.rs
+++ b/src/plugin/test/state_test.rs
@@ -9,6 +9,7 @@ mod tests {
         game_state::GameState,
         hare::{Hare, TeamEnum},
         r#move::Move,
+        rules_engine::RulesEngine,
     };
 
     fn create_player(
@@ -31,13 +32,15 @@ mod tests {
     fn create_board() -> Board {
         Board::new(vec![
             Field::Start,
-            Field::Salad,
+            Field::Carrots,
             Field::Position2,
             Field::Hare,
-            Field::Carrots,
-            Field::Market,
             Field::Position1,
+            Field::Market,
+            Field::Carrots,
             Field::Hare,
+            Field::Hedgehog,
+            Field::Salad,
             Field::Goal,
         ])
     }
@@ -79,5 +82,84 @@ mod tests {
             1,
             vec![Card::HurryAhead, Card::FallBack, Card::EatSalad]
         )))));
+    }
+
+    #[test]
+    fn test_correct_carrot_update() {
+        let state_depth_0 = GameState::new(
+            create_board(),
+            0,
+            create_player(TeamEnum::One, 0, vec![], 75, 0),
+            create_player(TeamEnum::Two, 0, vec![], 200, 0),
+            None,
+        );
+
+        // perform all poss moves for current player ("A")
+        let moves_depth_0 = state_depth_0.possible_moves();
+        for move_depth_0 in moves_depth_0.iter() {
+            let depth_1 = state_depth_0.perform_move(move_depth_0);
+            assert!(depth_1.is_ok());
+
+            match depth_1 {
+                Ok(state_depth_1) => {
+                    let moves_depth_1 = state_depth_1.possible_moves();
+                    let ref move_first_depth_1 = moves_depth_1[0];
+                    let ref move_last_depth_1 = moves_depth_1[moves_depth_1.len() - 1];
+                    
+                    // performed player "A" on Pos1 or Pos2 Field -> calculate next depth (player B)
+                    let on_pos1 = state_depth_1.board.get_field(state_depth_1.clone_other_player().position) == Some(Field::Position1);
+                    let on_pos2 = state_depth_1.board.get_field(state_depth_1.clone_other_player().position) == Some(Field::Position2);
+                    if on_pos1 || on_pos2 {
+
+                        let moved_distance = match &move_depth_0.action {
+                            Action::Advance(advance) => advance.distance,
+                            _ => 0,
+                        };
+
+                        let expected_carrots = state_depth_0.clone_current_player().carrots - RulesEngine::calculates_carrots(moved_distance);
+                        
+                        // player "A" should be missing the exact carrot amount for the distance
+                        assert_eq!(expected_carrots, state_depth_1.clone_other_player().carrots);
+
+                        // first (shortest) poss move of player "B" gets performed -> A is (with this board) in front
+                        let depth_2_first = state_depth_1.perform_move(move_first_depth_1);
+                        assert!(depth_2_first.is_ok());
+                        match depth_2_first {
+                            Ok(state_depth_2_first) => {
+                                // "A" got the 10 ten extra carrots if on pos1 field and in front
+                                if on_pos1 {
+                                    assert_eq!(expected_carrots + 10, state_depth_2_first.clone_current_player().carrots);
+                                }
+
+                                // no carrots should have been added to "A" if on pos2 field and in front
+                                if on_pos2 {
+                                    assert_eq!(expected_carrots, state_depth_2_first.clone_current_player().carrots);
+                                }
+                            }
+                            Err(e) => println!("Error {e}")
+                        }
+
+                        // last (farthest) poss move of player "B" gets performed -> A is (with this board) behind
+                        let depth_2_last = state_depth_1.perform_move(move_last_depth_1);
+                        assert!(depth_2_last.is_ok());
+                        match depth_2_last {
+                            Ok(state_depth_2_last) => {
+                                // no carrots should have been added to "A" if on pos1 field and behind
+                                if on_pos1 {
+                                    assert_eq!(expected_carrots, state_depth_2_last.clone_current_player().carrots);
+                                }
+
+                                // "A" got the 30 ten extra carrots if on pos2 field and behind
+                                if on_pos2 {
+                                    assert_eq!(expected_carrots + 30, state_depth_2_last.clone_current_player().carrots);
+                                }
+                            }
+                            Err(e) => println!("Error {e}")
+                        }
+                    }
+                },
+                Err(e) => println!("Error {e}")
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
Fix: tiny but extremely breaking change in gamestate.perform_move(), where the carrots for pos1 and pos2 field have not been calculated correctly.
Add: gamestate.last_move to move.perform, was forgotten as "gamestate.last_move" got added.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- With GUI Server on logs
- Test: New test for the fix, looks complicated, but it is basically a depth 2 calculation for the perform, with the options that the other player is in front or behind. Because of that I need to make changes to the test board in state_test.rs, but all other test still finish.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
