### PR TITLE
Swap carrots bug

### DIFF
--- a/src/plugin/action/advance.rs
+++ b/src/plugin/action/advance.rs
@@ -84,7 +84,7 @@ impl Advance {
 
                     last_card = Some(card);
 
-                    card.perform(state, remaining_cards.clone())?;
+                    card.perform(state, remaining_cards.clone(), self.distance)?;
                     player = state.clone_current_player();
                 }
                 _ => Err(HUIError::new_err("Card cannot be played on this field"))?,

--- a/src/plugin/test/card_test.rs
+++ b/src/plugin/test/card_test.rs
@@ -12,22 +12,25 @@ mod tests {
     fn create_test_game_state() -> GameState {
         let board = Board::new(vec![
             Field::Start,
-            Field::Position1,
+            Field::Carrots,
             Field::Position2,
             Field::Hare,
+            Field::Position1,
+            Field::Market,
+            Field::Carrots,
+            Field::Hare,
+            Field::Carrots,
             Field::Hedgehog,
             Field::Salad,
-            Field::Hare,
-            Field::Position1,
             Field::Goal,
         ]);
         let player_one = Hare::new(
             TeamEnum::One,
             Some(vec![Card::FallBack, Card::EatSalad, Card::SwapCarrots]),
-            Some(60),
+            Some(30),
             Some(3),
             None,
-            Some(6),
+            Some(7),
         );
         let player_two = Hare::new(
             TeamEnum::Two,
@@ -45,7 +48,7 @@ mod tests {
         let mut state = create_test_game_state();
         let fallback_card = Card::FallBack;
         assert!(fallback_card
-            .perform(&mut state, vec![Card::EatSalad, Card::SwapCarrots])
+            .perform(&mut state, vec![Card::EatSalad, Card::SwapCarrots], 0)
             .is_ok());
         let current_player = state.clone_current_player();
         assert_eq!(current_player.position, 2);
@@ -56,9 +59,9 @@ mod tests {
         let mut state = create_test_game_state();
         state.turn = 1;
         let hurry_ahead_card: Card = Card::HurryAhead;
-        assert!(hurry_ahead_card.perform(&mut state, vec![]).is_ok());
+        assert!(hurry_ahead_card.perform(&mut state, vec![], 0).is_ok());
         let current_player = state.clone_current_player();
-        assert_eq!(current_player.position, 7);
+        assert_eq!(current_player.position, 8);
     }
 
     #[test]
@@ -66,57 +69,117 @@ mod tests {
         let mut state = create_test_game_state();
         let eat_salad_card = Card::EatSalad;
         assert!(eat_salad_card
-            .perform(&mut state, vec![Card::FallBack, Card::SwapCarrots])
+            .perform(&mut state, vec![Card::FallBack, Card::SwapCarrots], 0)
             .is_ok());
         let current_player = state.clone_current_player();
         assert_eq!(current_player.salads, 2);
     }
 
     #[test]
-    fn test_swapcarrots_card() {
+    fn test_swapcarrots_card_general() {
         let mut state = create_test_game_state();
+
+        // modify player one
         let mut player_one = state.clone_current_player();
-        let mut player_two = state.clone_other_player();
-        player_one.position = 3;
-        player_two.position = 2;
+        player_one.last_move = Some(Move {
+            action: Action::Advance(Advance {
+                distance: 2,
+                cards: vec![],
+            }),
+        });
+
         state.update_player(player_one);
+
+        // modify player two
+        let mut player_two = state.clone_other_player();
+        player_two.last_move = Some(Move {
+            action: Action::Advance(Advance {
+                distance: 3,
+                cards: vec![],
+            }),
+        });
+        
         state.update_player(player_two);
 
+        // test card
         let swap_carrots_card = Card::SwapCarrots;
         assert!(swap_carrots_card
-            .perform(&mut state, vec![Card::FallBack, Card::EatSalad])
+            .perform(&mut state, vec![Card::FallBack, Card::EatSalad], 1)
             .is_ok());
         let current_player = state.clone_current_player();
         let other_player = state.clone_other_player();
         assert_eq!(current_player.carrots, 60);
-        assert_eq!(other_player.carrots, 60);
+        assert_eq!(other_player.carrots, 30);
     }
 
     #[test]
-    fn test_swapcarrots_card_already_occurred_last_two_rounds() {
+    fn test_swapcarrots_card_bought_last_two_rounds() {
         let mut state = create_test_game_state();
+
+        // modify player one
         let mut player_one = state.clone_current_player();
-        let mut player_two = state.clone_other_player();
-        player_one.position = 3;
-        player_two.position = 2;
         player_one.last_move = Some(Move {
             action: Action::Advance(Advance {
                 distance: 1,
                 cards: vec![Card::SwapCarrots],
             }),
         });
+
+        state.update_player(player_one);
+
+        // modify player two
+        let mut player_two = state.clone_other_player();
         player_two.last_move = Some(Move {
             action: Action::Advance(Advance {
-                distance: 1,
+                distance: 3,
+                cards: vec![],
+            }),
+        });
+        
+        state.update_player(player_two);
+
+        // test card
+        let swap_carrots_card = Card::SwapCarrots;
+        assert!(swap_carrots_card
+            .perform(&mut state, vec![Card::FallBack, Card::EatSalad], 2)
+            .is_ok());
+        let current_player = state.clone_current_player();
+        let other_player = state.clone_other_player();
+        assert_eq!(current_player.carrots, 60);
+        assert_eq!(other_player.carrots, 30);
+    }
+
+    #[test]
+    fn test_swapcarrots_card_played_last_two_rounds() {
+        let mut state = create_test_game_state();
+
+        // modify player one
+        let mut player_one = state.clone_current_player();
+        player_one.last_move = Some(Move {
+            action: Action::Advance(Advance {
+                distance: 2,
+                cards: vec![],
+            }),
+        });
+
+        state.update_player(player_one);
+
+        // modify player two
+        let mut player_two = state.clone_other_player();
+        player_two.last_move = Some(Move {
+            action: Action::Advance(Advance {
+                distance: 3,
                 cards: vec![Card::SwapCarrots],
             }),
         });
-        state.update_player(player_one);
+        
         state.update_player(player_two);
 
+        // test card
         let swap_carrots_card = Card::SwapCarrots;
-        let result = swap_carrots_card.perform(&mut state, vec![Card::FallBack, Card::EatSalad]);
-        assert!(result.is_err());
+        assert!(swap_carrots_card
+            .perform(&mut state, vec![Card::FallBack, Card::EatSalad], 1)
+            .is_err());
     }
 
     #[test]
@@ -124,7 +187,7 @@ mod tests {
         let mut state = create_test_game_state();
         state.turn = 1;
         let card_not_owned = Card::FallBack;
-        let result = card_not_owned.perform(&mut state, vec![Card::HurryAhead]);
+        let result = card_not_owned.perform(&mut state, vec![Card::HurryAhead], 0);
         assert!(result.is_err());
     }
 
@@ -135,7 +198,7 @@ mod tests {
         let mut current_player = state.clone_current_player();
         current_player.position = 1;
         state.update_player(current_player);
-        let result = card.perform(&mut state, vec![Card::EatSalad, Card::SwapCarrots]);
+        let result = card.perform(&mut state, vec![Card::EatSalad, Card::SwapCarrots], 0);
         assert!(result.is_err());
     }
 
@@ -144,7 +207,7 @@ mod tests {
         let mut state = create_test_game_state();
         let invalid_card = Card::FallBack;
         state.board.track.clear();
-        let result = invalid_card.perform(&mut state, vec![Card::EatSalad, Card::SwapCarrots]);
+        let result = invalid_card.perform(&mut state, vec![Card::EatSalad, Card::SwapCarrots], 0);
         assert!(result.is_err());
     }
 
@@ -156,7 +219,7 @@ mod tests {
         current_player.salads = 0;
         current_player.cards = vec![card];
         state.update_player(current_player);
-        let result = card.perform(&mut state, vec![]);
+        let result = card.perform(&mut state, vec![], 0);
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Description
There was a bug about the swap carrot card, with the "not after swap card in last two turns" rule, because a check for market fields has been missing. using it after buying is legal.
I split up the check and needed the current turn distance to calculate if the player is now on market or hare field.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Tested manually on gui server
Added/Modified Swap Carrot Unit Tests
Adapted all other card test to the new changes

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
