### PR TITLE
fix: enter goal bug in rules + tests

### DIFF
--- a/src/plugin/rules_engine.rs
+++ b/src/plugin/rules_engine.rs
@@ -107,6 +107,8 @@ impl RulesEngine {
             return Err(HUIError::new_err("Field is occupied by opponent"));
         }
 
+        let needed_carrots = RulesEngine::calculates_carrots(distance.try_into().unwrap());
+
         match field {
             Field::Hedgehog => Err(HUIError::new_err("Cannot advance on Hedgehog field")),
             Field::Salad if player.salads > 0 => Ok(()),
@@ -115,7 +117,7 @@ impl RulesEngine {
             Field::Hare => Err(HUIError::new_err("No card to play")),
             Field::Market if player.carrots >= 10 && !cards.is_empty() => Ok(()),
             Field::Market => Err(HUIError::new_err("Not enough carrots or no card to play")),
-            Field::Goal if player.carrots <= 10 && player.salads == 0 => Ok(()),
+            Field::Goal if player.carrots - needed_carrots <= 10 && player.salads == 0 => Ok(()),
             Field::Goal => Err(HUIError::new_err("Too many carrots or salads")),
             _ => Ok(()),
         }

--- a/src/plugin/test/rules_test.rs
+++ b/src/plugin/test/rules_test.rs
@@ -85,6 +85,21 @@ mod tests {
         assert!(RulesEngine::can_move_to(&board, 5, &player_one, &player_two, vec![]).is_err());
 
         player_one.cards = vec![];
+        player_one.carrots = 60;
         assert!(RulesEngine::can_move_to(&board, 6, &player_one, &player_two, vec![]).is_err());
+
+        // goal
+        //  too many salads and carrots
+        assert!(RulesEngine::can_move_to(&board, 8, &player_one, &player_two, vec![]).is_err());
+        //  salads ok, too many carrots
+        player_one.salads = 0;
+        assert!(RulesEngine::can_move_to(&board, 8, &player_one, &player_two, vec![]).is_err());
+        //  too many salads, carrots ok
+        player_one.carrots = 45;
+        player_one.salads = 3;
+        assert!(RulesEngine::can_move_to(&board, 8, &player_one, &player_two, vec![]).is_err());
+        //  all ok
+        player_one.salads = 0;
+        assert!(RulesEngine::can_move_to(&board, 8, &player_one, &player_two, vec![]).is_ok());
     }
 }


### PR DESCRIPTION
## Description
There was a bug about the rules check if the player is able to enter the goal (carrots <= 10 && salads == 0)
When checking the carrots, the needed carrots for the turn need to be considered in that check

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Checked by hand in GUI Server, Unit tests (old and new)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
