### PR TITLE
chore: make python-only functions not public

### DIFF
--- a/src/plugin2026/board.rs
+++ b/src/plugin2026/board.rs
@@ -23,12 +23,11 @@ impl Board {
         Self { map }
     }
 
-    pub fn __str__(&self) -> String {self.to_string()}
-    pub fn __repr__(&self) -> String {format!("{:?}", self)}
-    pub fn __eq__(&self, other: &Board) -> bool {self == other}
-    pub fn __ne_(&self, other: &Board) -> bool {self != other}
-
-    pub fn deepcopy(&self) -> Board {self.clone()}
+    fn __str__(&self) -> String {self.to_string()}
+    fn __repr__(&self) -> String {format!("{:?}", self)}
+    fn __eq__(&self, other: &Board) -> bool {self == other}
+    fn __ne__(&self, other: &Board) -> bool {self != other}
+    fn deepcopy(&self) -> Board {self.clone()}
 
     pub fn get_field(&self, position: &Coordinate) -> Option<FieldType> {
 

--- a/src/plugin2026/field_type.rs
+++ b/src/plugin2026/field_type.rs
@@ -17,10 +17,10 @@ pub enum FieldType {
 
 #[pymethods]
 impl FieldType {
-    pub fn __str__(&self) -> String {self.to_string()}
-    pub fn __repr__(&self) -> String {format!("{:?}", self)}
-    pub fn __eq__(&self, other: &FieldType) -> bool {self == other}
-    pub fn __ne_(&self, other: &FieldType) -> bool {self != other}
+    fn __str__(&self) -> String {self.to_string()}
+    fn __repr__(&self) -> String {format!("{:?}", self)}
+    fn __eq__(&self, other: &FieldType) -> bool {self == other}
+    fn __ne__(&self, other: &FieldType) -> bool {self != other}
     
     pub fn get_value(&self) -> usize {
         match self {

--- a/src/plugin2026/game_state.rs
+++ b/src/plugin2026/game_state.rs
@@ -29,12 +29,11 @@ impl GameState {
         }
     }
 
-    pub fn __str__(&self) -> String {self.to_string()}
-    pub fn __repr__(&self) -> String {format!("{:?}", self)}
-    pub fn __eq__(&self, other: &GameState) -> bool {self == other}
-    pub fn __ne__(&self, other: &GameState) -> bool {self != other}
-    
-    pub fn deepcopy(&self) -> GameState {self.clone()}
+    fn __str__(&self) -> String {self.to_string()}
+    fn __repr__(&self) -> String {format!("{:?}", self)}
+    fn __eq__(&self, other: &GameState) -> bool {self == other}
+    fn __ne__(&self, other: &GameState) -> bool {self != other}
+    fn deepcopy(&self) -> GameState {self.clone()}
 
     pub fn set_board_field(&mut self, position: &Coordinate, field: FieldType) -> Result<(), PyErr> {
         let x = position.x as usize;

--- a/src/plugin2026/move.rs
+++ b/src/plugin2026/move.rs
@@ -27,12 +27,11 @@ impl Move {
         }
     }
 
-    pub fn __str__(&self) -> String {self.to_string()}
-    pub fn __repr__(&self) -> String {format!("{:?}", self)}
-    pub fn __eq__(&self, other: &Move) -> bool {self == other}
-    pub fn __ne_(&self, other: &Move) -> bool {self != other}
-    
-    pub fn deepcopy(&self) -> Move {self.clone()}
+    fn __str__(&self) -> String {self.to_string()}
+    fn __repr__(&self) -> String {format!("{:?}", self)}
+    fn __eq__(&self, other: &Move) -> bool {self == other}
+    fn __ne__(&self, other: &Move) -> bool {self != other}
+    fn deepcopy(&self) -> Move {self.clone()}
 }
 
 impl std::fmt::Display for Move {

--- a/src/plugin2026/utils/coordinate.rs
+++ b/src/plugin2026/utils/coordinate.rs
@@ -20,12 +20,11 @@ impl Coordinate {
         }
     }
 
-    pub fn __str__(&self) -> String {self.to_string()}
-    pub fn __repr__(&self) -> String {format!("{:?}", self)}
-    pub fn __eq__(&self, other: &Coordinate) -> bool {self == other}
-    pub fn __ne_(&self, other: &Coordinate) -> bool {self != other}
-    
-    pub fn deepcopy(&self) -> Coordinate {*self}
+    fn __str__(&self) -> String {self.to_string()}
+    fn __repr__(&self) -> String {format!("{:?}", self)}
+    fn __eq__(&self, other: &Coordinate) -> bool {self == other}
+    fn __ne__(&self, other: &Coordinate) -> bool {self != other}
+    fn deepcopy(&self) -> Coordinate {*self}
 
     pub fn add_vector(&self, vector: &Vector) -> Coordinate {
         Coordinate {
@@ -35,6 +34,7 @@ impl Coordinate {
     }
 
     pub fn add_vector_mut(&mut self, vector: &Vector) {
+
         self.x += vector.delta_x;
         self.y += vector.delta_y;
     }

--- a/src/plugin2026/utils/direction.rs
+++ b/src/plugin2026/utils/direction.rs
@@ -19,12 +19,11 @@ pub enum Direction {
 
 #[pymethods]
 impl Direction {
-    pub fn __str__(&self) -> String {self.to_string()}
-    pub fn __repr__(&self) -> String {format!("{:?}", self)}
-    pub fn __eq__(&self, other: &Direction) -> bool {self == other}
-    pub fn __ne_(&self, other: &Direction) -> bool {self != other}
-
-    pub fn deepcopy(&self) -> Direction {*self}
+    fn __str__(&self) -> String {self.to_string()}
+    fn __repr__(&self) -> String {format!("{:?}", self)}
+    fn __eq__(&self, other: &Direction) -> bool {self == other}
+    fn __ne__(&self, other: &Direction) -> bool {self != other}
+    fn deepcopy(&self) -> Direction {*self}
 
     #[staticmethod]
     pub fn from_vector(vector: &Vector) -> Option<Direction> {

--- a/src/plugin2026/utils/team.rs
+++ b/src/plugin2026/utils/team.rs
@@ -11,10 +11,10 @@ pub enum TeamEnum {
 
 #[pymethods]
 impl TeamEnum {
-    pub fn __str__(&self) -> String {self.to_string()}
-    pub fn __repr__(&self) -> String {format!("{:?}", self)}
-    pub fn __eq__(&self, other: &TeamEnum) -> bool {self == other}
-    pub fn __ne_(&self, other: &TeamEnum) -> bool {self != other}
+    fn __str__(&self) -> String {self.to_string()}
+    fn __repr__(&self) -> String {format!("{:?}", self)}
+    fn __eq__(&self, other: &TeamEnum) -> bool {self == other}
+    fn __ne__(&self, other: &TeamEnum) -> bool {self != other}
 
     pub fn get_fish_types(&self) -> Vec<FieldType> {
         match self {

--- a/src/plugin2026/utils/vector.rs
+++ b/src/plugin2026/utils/vector.rs
@@ -18,12 +18,11 @@ impl Vector {
         }
     }
 
-    pub fn __str__(&self) -> String {self.to_string()}
-    pub fn __repr__(&self) -> String {format!("{:?}", self)}
-    pub fn __eq__(&self, other: &Vector) -> bool {self == other}
-    pub fn __ne_(&self, other: &Vector) -> bool {self != other}
-
-    pub fn deepcopy(&self) -> Vector {*self}
+    fn __str__(&self) -> String {self.to_string()}
+    fn __repr__(&self) -> String {format!("{:?}", self)}
+    fn __eq__(&self, other: &Vector) -> bool {self == other}
+    fn __ne__(&self, other: &Vector) -> bool {self != other}
+    fn deepcopy(&self) -> Vector {*self}
 
     pub fn add_vector(&self, other: &Vector) -> Vector {
         Vector {


### PR DESCRIPTION
## Description
Change rust functions, that only got in use in python to private

## Type of change
- [x] Beauty change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
does work

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
