### PR TITLE
feat(rulesengine): add 2 swarm methods for python 

### DIFF
--- a/python/socha/_socha.pyi
+++ b/python/socha/_socha.pyi
@@ -785,10 +785,45 @@ class RulesEngine:
         Es wird nicht beachtet, ob die Zahl kleiner 0 oder größer 59 ist.
 
         Args:
-            turn (int): Die Zugzahl
+            turn (int): Die Zugzahl.
 
         Returns:
             TeamEnum: Das Team, was dran ist.
+        """
+        ...
+
+    @staticmethod
+    def swarm_from(board: Board, position: Coordinate) -> List[Coordinate]:
+        """
+        Berechnet auf einem Spielbrett von einer Startposition aus, welche Fische
+        von dort aus in einem Schwarm zusammenhängen.
+        Dabei werden nur Fische beachtet, die im selben Team sind, wie der auf dem Startfeld.
+        Gibt eine Liste an Koordinaten zurück, die leer ist, wenn die Startposition
+        außerhalb des Spielbrettes ist, oder kein Fisch als Start angegeben ist.
+
+        Args:
+            board (Board): Das Spielbrett.
+            position (Coordinate): Die Startkoordinate
+
+        Returns:
+            List[Coordinate]: Die Liste an zusammenhängenden Fischen.
+
+        """
+        ...
+
+    @staticmethod
+    def swarms_of_team(board: Board, team: TeamEnum) -> List[List[Coordinate]]:
+        """
+        Berechnet auf einem Spielbrett alle Schwärme, die ein Team gerade gebildet hat.
+        Gibt eine 2-Dimensionale Liste zurück, wobei jede Sub-Liste ein einzelner Schwarm ist.
+
+        Args:
+            board (Board): Das Spielbrett.
+            team (TeamEnum): Das gewählte Team.
+
+        Returns:
+            List[List[Coordinate]]: Die Liste an Schwärmen.
+
         """
         ...
 


### PR DESCRIPTION
…to get closer to java api (performance wise)

## Description
Add RulesEngine::swarm_from and RulesEngine::swarms_of_team for python and one helper rust only method

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Compared Results to previous made only Python method (which had bad performance)

New Unit tests will follow, but should be working

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
